### PR TITLE
Fix typo in Dutch translation

### DIFF
--- a/.homeycompose/flow/actions/event_clear.json
+++ b/.homeycompose/flow/actions/event_clear.json
@@ -32,7 +32,7 @@
     },
     "hint": {
         "en": "Clears all stored history for the event.",
-        "nl": "Leeft alle opgeslagen geschiedenis voor de gebeurtenis.",
+        "nl": "Leegt alle opgeslagen geschiedenis voor de gebeurtenis.",
         "da": "Nulstiller al gemt historik for begivenheden.",
         "de": "Löscht den gesamten gespeicherten Verlauf für das Ereignis.",
         "es": "Borra todo el historial almacenado para el evento.",

--- a/.homeycompose/flow/actions/event_clear_all.json
+++ b/.homeycompose/flow/actions/event_clear_all.json
@@ -32,7 +32,7 @@
     },
     "hint": {
         "en": "Clears all stored history for all events.",
-        "nl": "Leeft alle opgeslagen geschiedenis voor alle gebeurtenissen.",
+        "nl": "Leegt alle opgeslagen geschiedenis voor alle gebeurtenissen.",
         "da": "Rydder al gemt historie for alle begivenheder.",
         "de": "Löscht den gesamten gespeicherten Verlauf für alle Ereignisse.",
         "es": "Borra todo el historial almacenado para todos los eventos.",

--- a/app.json
+++ b/app.json
@@ -4903,7 +4903,7 @@
         },
         "hint": {
           "en": "Clears all stored history for the event.",
-          "nl": "Leeft alle opgeslagen geschiedenis voor de gebeurtenis.",
+          "nl": "Leegt alle opgeslagen geschiedenis voor de gebeurtenis.",
           "da": "Nulstiller al gemt historik for begivenheden.",
           "de": "Löscht den gesamten gespeicherten Verlauf für das Ereignis.",
           "es": "Borra todo el historial almacenado para el evento.",
@@ -4972,7 +4972,7 @@
         },
         "hint": {
           "en": "Clears all stored history for all events.",
-          "nl": "Leeft alle opgeslagen geschiedenis voor alle gebeurtenissen.",
+          "nl": "Leegt alle opgeslagen geschiedenis voor alle gebeurtenissen.",
           "da": "Rydder al gemt historie for alle begivenheder.",
           "de": "Löscht den gesamten gespeicherten Verlauf für alle Ereignisse.",
           "es": "Borra todo el historial almacenado para todos los eventos.",


### PR DESCRIPTION
Fix typo in Dutch translation of Event Clear flow cards: "Leeft" replaced by "Leegt"