### PR TITLE
Widget: Add view mode setting to event widget.

### DIFF
--- a/app.json
+++ b/app.json
@@ -10074,6 +10074,64 @@
             "ko": "이벤트",
             "ar": "حدث"
           }
+        },
+        {
+          "id": "view_mode",
+          "type": "dropdown",
+          "title": {
+            "en": "View mode",
+            "nl": "Weergavemodus",
+            "de": "Ansichtsmodus",
+            "fr": "Mode d’affichage",
+            "it": "Modalità di visualizzazione",
+            "sv": "Visningsläge",
+            "no": "Visningsmodus",
+            "es": "Modo de vista",
+            "da": "Visningstilstand",
+            "ru": "Режим просмотра",
+            "pl": "Tryb widoku",
+            "ko": "보기 모드",
+            "ar": "وضع العرض"
+          },
+          "value": "relative",
+          "values": [
+            {
+              "id": "relative",
+              "title": {
+                "en": "Relative time",
+                "nl": "Relatieve tijd",
+                "de": "Relative Zeit",
+                "fr": "Temps relatif",
+                "it": "Tempo relativo",
+                "sv": "Relativ tid",
+                "no": "Relativ tid",
+                "es": "Tiempo relativo",
+                "da": "Relativ tid",
+                "ru": "Относительное время",
+                "pl": "Czas względny",
+                "ko": "상대 시간",
+                "ar": "الوقت النسبي"
+              }
+            },
+            {
+              "id": "absolute",
+              "title": {
+                "en": "Absolute time",
+                "nl": "Absolute tijd",
+                "de": "Absolute Zeit",
+                "fr": "Temps absolu",
+                "it": "Tempo assoluto",
+                "sv": "Absolut tid",
+                "no": "Absolutt tid",
+                "es": "Tiempo absoluto",
+                "da": "Absolut tid",
+                "ru": "Абсолютное время",
+                "pl": "Czas bezwzględny",
+                "ko": "절대 시간",
+                "ar": "الوقت المطلق"
+              }
+            }
+          ]
         }
       ],
       "api": {

--- a/widgets/event/public/index.html
+++ b/widgets/event/public/index.html
@@ -106,8 +106,13 @@
 
             if (event?.lastUpdate) {
                 const lastUpdate = new Date(event.lastUpdate);
-                interval = setInterval(() => tick(lastUpdate), 1000);
-                tick(lastUpdate);
+
+                if (settings.view_mode === 'relative') {
+                    interval = setInterval(() => tick(lastUpdate), 1000);
+                    tick(lastUpdate);
+                } else {
+                    eventValue.innerText = formatterDate.format(lastUpdate);
+                }
             }
 
             const height = document.body.getBoundingClientRect().height;

--- a/widgets/event/widget.compose.json
+++ b/widgets/event/widget.compose.json
@@ -34,6 +34,64 @@
                 "ko": "이벤트",
                 "ar": "حدث"
             }
+        },
+        {
+            "id": "view_mode",
+            "type": "dropdown",
+            "title": {
+                "en": "View mode",
+                "nl": "Weergavemodus",
+                "de": "Ansichtsmodus",
+                "fr": "Mode d’affichage",
+                "it": "Modalità di visualizzazione",
+                "sv": "Visningsläge",
+                "no": "Visningsmodus",
+                "es": "Modo de vista",
+                "da": "Visningstilstand",
+                "ru": "Режим просмотра",
+                "pl": "Tryb widoku",
+                "ko": "보기 모드",
+                "ar": "وضع العرض"
+            },
+            "value": "relative",
+            "values": [
+                {
+                    "id": "relative",
+                    "title": {
+                        "en": "Relative time",
+                        "nl": "Relatieve tijd",
+                        "de": "Relative Zeit",
+                        "fr": "Temps relatif",
+                        "it": "Tempo relativo",
+                        "sv": "Relativ tid",
+                        "no": "Relativ tid",
+                        "es": "Tiempo relativo",
+                        "da": "Relativ tid",
+                        "ru": "Относительное время",
+                        "pl": "Czas względny",
+                        "ko": "상대 시간",
+                        "ar": "الوقت النسبي"
+                    }
+                },
+                {
+                    "id": "absolute",
+                    "title": {
+                        "en": "Absolute time",
+                        "nl": "Absolute tijd",
+                        "de": "Absolute Zeit",
+                        "fr": "Temps absolu",
+                        "it": "Tempo assoluto",
+                        "sv": "Absolut tid",
+                        "no": "Absolutt tid",
+                        "es": "Tiempo absoluto",
+                        "da": "Absolut tid",
+                        "ru": "Абсолютное время",
+                        "pl": "Czas bezwzględny",
+                        "ko": "절대 시간",
+                        "ar": "الوقت المطلق"
+                    }
+                }
+            ]
         }
     ],
     "api": {


### PR DESCRIPTION
This PR introduces a new setting for the event widget. The setting is for displaying the time in a relative or absolute format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Event widget now includes a "View mode" setting with "Relative time" (default) and "Absolute time" options.
  * In "Relative" mode the event time updates live; in "Absolute" mode the event shows a formatted timestamp without live ticking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->